### PR TITLE
Fix CI/CD status display when tests are pending

### DIFF
--- a/backend/projects.py
+++ b/backend/projects.py
@@ -205,14 +205,22 @@ def get_github_status(repo_url, github_token):
             }
             
         status_data = status_response.json()
-        tests_passing = status_data.get('state') == 'success'
+        state = status_data.get('state', 'unknown')
         
-        logger.info(f"✅ GitHub status retrieved: {status_data.get('state')}")
+        # Handle different CI/CD states properly
+        if state == 'success':
+            tests_passing = True
+        elif state in ['pending', 'running']:
+            tests_passing = None  # Use None to indicate "in progress"
+        else:  # failure, error, or unknown
+            tests_passing = False
+        
+        logger.info(f"✅ GitHub status retrieved: {state}")
         
         return {
             'tests_passing': tests_passing,
             'last_commit': latest_commit_sha,
-            'status': status_data.get('state', 'unknown'),
+            'status': state,
             'total_count': status_data.get('total_count', 0)
         }
         

--- a/src/pages/ProjectDetail.css
+++ b/src/pages/ProjectDetail.css
@@ -136,6 +136,11 @@
   color: #991b1b;
 }
 
+.status.running {
+  background: #dbeafe;
+  color: #1e40af;
+}
+
 .status.loading {
   background: #fef3c7;
   color: #92400e;

--- a/src/pages/ProjectDetail.jsx
+++ b/src/pages/ProjectDetail.jsx
@@ -256,8 +256,14 @@ function ProjectDetail() {
               <h3>CI/CD Tests</h3>
               <div className="status-indicator">
                 {project.github_status ? (
-                  <span className={`status ${project.github_status.tests_passing ? 'success' : 'error'}`}>
-                    {project.github_status.tests_passing ? '✅ Passing' : '❌ Failing'}
+                  <span className={`status ${
+                    project.github_status.tests_passing === true ? 'success' : 
+                    project.github_status.tests_passing === false ? 'error' : 
+                    'running'
+                  }`}>
+                    {project.github_status.tests_passing === true ? '✅ Passing' : 
+                     project.github_status.tests_passing === false ? '❌ Failing' : 
+                     '🔄 Running'}
                   </span>
                 ) : (
                   <span className="status loading">🔄 Checking...</span>

--- a/src/pages/ProjectDetail.test.jsx
+++ b/src/pages/ProjectDetail.test.jsx
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { BrowserRouter } from 'react-router-dom'
+import ProjectDetail from './ProjectDetail'
+
+// Mock the uuid utility
+vi.mock('../utils/uuid', () => ({
+  getUserUUID: () => 'test-uuid-12345'
+}))
+
+// Mock useParams to return a test slug
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useParams: () => ({ slug: 'test-project' })
+  }
+})
+
+const renderProjectDetail = () => {
+  return render(
+    <BrowserRouter>
+      <ProjectDetail />
+    </BrowserRouter>
+  )
+}
+
+describe('ProjectDetail', () => {
+  beforeEach(() => {
+    // Reset all mocks before each test
+    vi.clearAllMocks()
+    
+    // Mock fetch globally
+    global.fetch = vi.fn()
+  })
+
+  it('displays "Running" status when CI/CD is pending', async () => {
+    // Mock project API response with pending CI/CD status
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        project: {
+          id: 1,
+          name: 'Test Project',
+          slug: 'test-project',
+          github_url: 'https://github.com/user/test-project',
+          created_at: '2025-01-01T00:00:00.000Z',
+          github_status: {
+            tests_passing: null, // null indicates pending/running
+            last_commit: 'abc1234567890',
+            status: 'pending',
+            total_count: 1
+          },
+          fly_status: {
+            deployed: true,
+            app_url: 'https://test-project.fly.dev',
+            status: 'running'
+          }
+        }
+      })
+    })
+
+    // Mock conversations API response
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        conversations: []
+      })
+    })
+
+    renderProjectDetail()
+
+    // Wait for the project to load
+    await waitFor(() => {
+      expect(screen.getByText('Test Project')).toBeInTheDocument()
+    })
+
+    // Check that CI/CD status shows "Running"
+    expect(screen.getByText('🔄 Running')).toBeInTheDocument()
+    expect(screen.queryByText('❌ Failing')).not.toBeInTheDocument()
+    expect(screen.queryByText('✅ Passing')).not.toBeInTheDocument()
+  })
+
+  it('displays "Passing" status when CI/CD is successful', async () => {
+    // Mock project API response with successful CI/CD status
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        project: {
+          id: 1,
+          name: 'Test Project',
+          slug: 'test-project',
+          github_url: 'https://github.com/user/test-project',
+          created_at: '2025-01-01T00:00:00.000Z',
+          github_status: {
+            tests_passing: true, // true indicates success
+            last_commit: 'abc1234567890',
+            status: 'success',
+            total_count: 1
+          },
+          fly_status: {
+            deployed: true,
+            app_url: 'https://test-project.fly.dev',
+            status: 'running'
+          }
+        }
+      })
+    })
+
+    // Mock conversations API response
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        conversations: []
+      })
+    })
+
+    renderProjectDetail()
+
+    // Wait for the project to load
+    await waitFor(() => {
+      expect(screen.getByText('Test Project')).toBeInTheDocument()
+    })
+
+    // Check that CI/CD status shows "Passing"
+    expect(screen.getByText('✅ Passing')).toBeInTheDocument()
+    expect(screen.queryByText('❌ Failing')).not.toBeInTheDocument()
+    expect(screen.queryByText('🔄 Running')).not.toBeInTheDocument()
+  })
+
+  it('displays "Failing" status when CI/CD has failed', async () => {
+    // Mock project API response with failed CI/CD status
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        project: {
+          id: 1,
+          name: 'Test Project',
+          slug: 'test-project',
+          github_url: 'https://github.com/user/test-project',
+          created_at: '2025-01-01T00:00:00.000Z',
+          github_status: {
+            tests_passing: false, // false indicates failure
+            last_commit: 'abc1234567890',
+            status: 'failure',
+            total_count: 1
+          },
+          fly_status: {
+            deployed: true,
+            app_url: 'https://test-project.fly.dev',
+            status: 'running'
+          }
+        }
+      })
+    })
+
+    // Mock conversations API response
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        conversations: []
+      })
+    })
+
+    renderProjectDetail()
+
+    // Wait for the project to load
+    await waitFor(() => {
+      expect(screen.getByText('Test Project')).toBeInTheDocument()
+    })
+
+    // Check that CI/CD status shows "Failing"
+    expect(screen.getByText('❌ Failing')).toBeInTheDocument()
+    expect(screen.queryByText('✅ Passing')).not.toBeInTheDocument()
+    expect(screen.queryByText('🔄 Running')).not.toBeInTheDocument()
+  })
+
+  it('displays "Checking..." status when github_status is null', async () => {
+    // Mock project API response with no github_status
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        project: {
+          id: 1,
+          name: 'Test Project',
+          slug: 'test-project',
+          github_url: 'https://github.com/user/test-project',
+          created_at: '2025-01-01T00:00:00.000Z',
+          github_status: null, // null indicates checking
+          fly_status: {
+            deployed: true,
+            app_url: 'https://test-project.fly.dev',
+            status: 'running'
+          }
+        }
+      })
+    })
+
+    // Mock conversations API response
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        conversations: []
+      })
+    })
+
+    renderProjectDetail()
+
+    // Wait for the project to load
+    await waitFor(() => {
+      expect(screen.getByText('Test Project')).toBeInTheDocument()
+    })
+
+    // Check that CI/CD status shows "Checking..."
+    expect(screen.getByText('🔄 Checking...')).toBeInTheDocument()
+    expect(screen.queryByText('❌ Failing')).not.toBeInTheDocument()
+    expect(screen.queryByText('✅ Passing')).not.toBeInTheDocument()
+    expect(screen.queryByText('🔄 Running')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Problem

When CI/CD tests are still running (status: "pending"), the project page incorrectly displays "❌ Failing" instead of showing that the tests are currently running.

## Root Cause

The issue was in both the backend and frontend:

1. **Backend**: The `get_github_status()` function was setting `tests_passing = false` for any non-success state, including "pending"
2. **Frontend**: The UI only handled boolean values for `tests_passing`, treating `false` as "Failed" regardless of the actual CI/CD state

## Solution

### Backend Changes (`backend/projects.py`)
- Modified `get_github_status()` to return `tests_passing = null` for pending/running states
- Now properly distinguishes between:
  - `true` → CI/CD passed
  - `false` → CI/CD failed  
  - `null` → CI/CD is running/pending

### Frontend Changes (`src/pages/ProjectDetail.jsx`)
- Updated status display logic to handle three states:
  - `tests_passing === true` → "✅ Passing" (green)
  - `tests_passing === false` → "❌ Failing" (red)
  - `tests_passing === null` → "🔄 Running" (blue)

### UI Changes (`src/pages/ProjectDetail.css`)
- Added blue styling for the new "running" status to visually distinguish it from the loading state

### Testing (`src/pages/ProjectDetail.test.jsx`)
- Added comprehensive test coverage for all CI/CD status states
- Verifies correct display for pending, success, failure, and null states

## Testing

All existing tests continue to pass (46/46), plus 4 new tests specifically for the CI/CD status display logic.

```bash
npm run test:run
# ✓ 46 tests passed
```

## Before/After

**Before**: Pending CI/CD → "❌ Failing" (incorrect)
**After**: Pending CI/CD → "🔄 Running" (correct)

This fix ensures users get accurate, real-time feedback about their CI/CD pipeline status.

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d73f57614ada4f6d8c05f68d741fac99)