### PR TITLE
Add basic authentication with hardcoded credentials

### DIFF
--- a/.htpasswd
+++ b/.htpasswd
@@ -1,0 +1,1 @@
+openhands:$apr1$cUovkHFi$eTXxaMGM7HbvBxY7/E9OY1

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,9 @@ RUN mkdir -p /data && chown -R www-data:www-data /data
 # Copy nginx configuration
 COPY nginx.conf /etc/nginx/sites-available/default
 
+# Copy htpasswd file for basic authentication
+COPY .htpasswd /etc/nginx/.htpasswd
+
 # Copy supervisor configuration
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -2,6 +2,10 @@ server {
     listen 80;
     server_name _;
     
+    # Basic Authentication
+    auth_basic "OpenVibe Access";
+    auth_basic_user_file /etc/nginx/.htpasswd;
+    
     # Serve React frontend
     location / {
         root /usr/share/nginx/html;


### PR DESCRIPTION
## Summary

This PR adds basic authentication to the OpenVibe application using nginx's `auth_basic` module with hardcoded credentials as requested.

## Changes Made

- **Created `.htpasswd` file** with encrypted credentials:
  - Username: `openhands`
  - Password: `flarglebargle`

- **Updated `nginx.conf`** to enable basic authentication:
  - Added `auth_basic "OpenVibe Access";` directive
  - Added `auth_basic_user_file /etc/nginx/.htpasswd;` directive
  - Protects the entire application (both frontend and API endpoints)

- **Updated `Dockerfile`** to include the htpasswd file:
  - Added `COPY .htpasswd /etc/nginx/.htpasswd` to copy credentials into container

## Authentication Behavior

- **Without credentials**: Returns `401 Unauthorized` with basic auth challenge
- **With correct credentials**: Returns `200 OK` and serves content
- **With incorrect credentials**: Returns `401 Unauthorized`

## Security Implementation

The authentication is implemented at the nginx level, providing a single authentication point that protects:
- ✅ Frontend React application
- ✅ All API endpoints (`/api/*`)
- ✅ Integration endpoints (`/integrations/*`)
- ✅ Health check endpoint (`/health`)

## Testing

All authentication scenarios have been tested:
- ✅ Unauthenticated requests are properly rejected
- ✅ Correct credentials allow access to all endpoints
- ✅ Incorrect credentials are rejected
- ✅ Both frontend and backend are protected

The implementation uses nginx's built-in basic authentication which is secure and performant for this use case.

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d724679a587d4f8a846d79feb8cbe139)