### PR TITLE
Move system prompt from agent-sdk to local file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,5 +191,5 @@ venv.bak/
 .dmypy.json
 dmypy.json
 
-# Jinja template cache
+# Jinja2 template cache
 .jinja_cache/

--- a/backend/prompts/system_prompt.j2
+++ b/backend/prompts/system_prompt.j2
@@ -69,15 +69,12 @@ Your primary role is to assist users by executing commands, modifying code, and 
 # 🔐 Security Risk Policy
 When using tools that support the security_risk parameter, assess the safety risk of your actions:
 
-
 - **LOW**: Read-only actions inside sandbox.
   - Inspecting container files, calculations, viewing docs.
 - **MEDIUM**: Container-scoped edits and installs.
   - Modify workspace files, install packages system-wide inside container, run user code.
 - **HIGH**: Data exfiltration or privilege breaks.
   - Sending secrets/local data out, connecting to host filesystem, privileged container ops, running unverified binaries with network access.
-
-
 
 **Global Rules**
 - Always escalate to **HIGH** if sensitive data leaves the environment.
@@ -185,7 +182,7 @@ When using the FileEditor tool, always use absolute paths.
 Only work on the current branch. Push to its analog on the remote branch.
 
 <IMPORTANT>
-COMMIT AND PUSH your work whenver you've made an improvement. DO NOT wait for the user to tell you to push.
+COMMIT AND PUSH your work whenever you've made an improvement. DO NOT wait for the user to tell you to push.
 </IMPORTANT>
 
 Whenever you push substantial changes, update the PR title and description as necessary,


### PR DESCRIPTION
## Summary

This PR moves the system prompt from the agent-sdk to a local file in the OpenVibe repository, providing better control over the agent's behavior and instructions.

## Changes Made

- **Copied complete system prompt** from agent-sdk to `backend/prompts/system_prompt.j2`
- **Removed push permission restrictions** to allow automatic commits/pushes as intended for the OpenVibe workflow
- **Added comprehensive task management instructions** including detailed examples and best practices
- **Modified agent_loop.py** to use the local system prompt template with proper workspace_path context
- **Updated .gitignore** to exclude Jinja2 template cache files

## Technical Details

- Created a `CustomAgent` class that overrides the `system_message` property to use our local template
- Used `CustomAgentContext` to properly pass the `workspace_path` to the template rendering
- Integrated all previous system message suffix content directly into the main template
- Fixed typo in push instructions ("whenver" → "whenever")

## Benefits

- **Local control**: System prompt can now be modified without waiting for agent-sdk updates
- **Customization**: Tailored specifically for OpenVibe's workflow and requirements
- **Consistency**: All workspace and workflow instructions are now in one place
- **Maintainability**: Easier to update and version control the agent's behavior

## Testing

- Verified that the agent can be created successfully with the new system prompt
- Confirmed that workspace_path is properly substituted in the template
- Validated that all expected sections (push instructions, task management, etc.) are present

The system prompt now includes comprehensive task management guidelines and removes the restriction on automatic pushing, aligning with OpenVibe's intended workflow.

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/968b5bab5962456ba303af282ec19cfe)