### PR TITLE
Update Claude model from haiku to sonnet-4

### DIFF
--- a/backend/keys.py
+++ b/backend/keys.py
@@ -86,7 +86,7 @@ def validate_anthropic_key(api_key):
             "https://api.anthropic.com/v1/messages",
             headers=headers,
             json={
-                "model": "claude-3-haiku-20240307",
+                "model": "claude-sonnet-4-20250514",
                 "max_tokens": 1,
                 "messages": [{"role": "user", "content": "Hi"}],
             },

--- a/backend/mocks.py
+++ b/backend/mocks.py
@@ -191,7 +191,7 @@ def mock_anthropic_messages_response():
             "type": "message",
             "role": "assistant",
             "content": [{"type": "text", "text": "Mock response from Claude"}],
-            "model": "claude-3-haiku-20240307",
+            "model": "claude-sonnet-4-20250514",
             "stop_reason": "end_turn",
             "usage": {"input_tokens": 10, "output_tokens": 5},
         },

--- a/backend/routes/riffs.py
+++ b/backend/routes/riffs.py
@@ -41,7 +41,7 @@ class MockLLM:
         return MockResponse()
 
 
-def get_llm_instance(api_key: str, model: str = "claude-3-haiku-20240307"):
+def get_llm_instance(api_key: str, model: str = "claude-sonnet-4-20250514"):
     """Get the appropriate LLM instance based on MOCK_MODE environment variable"""
     if os.environ.get("MOCK_MODE", "false").lower() == "true":
         # In mock mode, create a real LLM instance but with a fake key
@@ -107,7 +107,7 @@ def reconstruct_agent_from_state(user_uuid, app_slug, riff_slug):
         # Create LLM instance
         try:
             llm = get_llm_instance(
-                api_key=anthropic_token, model="claude-3-haiku-20240307"
+                api_key=anthropic_token, model="claude-sonnet-4-20250514"
             )
 
             # Create message callback to store events as messages
@@ -235,7 +235,7 @@ def create_agent_for_user(user_uuid, app_slug, riff_slug, send_initial_message=F
         # Create LLM instance
         try:
             llm = get_llm_instance(
-                api_key=anthropic_token, model="claude-3-haiku-20240307"
+                api_key=anthropic_token, model="claude-sonnet-4-20250514"
             )
 
             # Create message callback to store events as messages


### PR DESCRIPTION
## Summary

This PR updates all Claude model references throughout the backend codebase from `claude-3-haiku-20240307` to `claude-sonnet-4-20250514`.

## Changes Made

- **backend/mocks.py**: Updated mock response model reference
- **backend/routes/riffs.py**: Updated default model parameter in `get_llm_instance()` function and all LLM instance creations
- **backend/keys.py**: Updated model reference in Anthropic API key validation

## Details

- Replaced 5 total occurrences of `claude-3-haiku-20240307` with `claude-sonnet-4-20250514`
- All changes maintain backward compatibility as they only affect the model parameter
- No functional changes to the application logic
- Ensures consistent use of the latest Claude Sonnet 4 model throughout the application

## Testing

- Verified no remaining references to the old model exist in the codebase
- All model references now consistently use `claude-sonnet-4-20250514`
- Changes are isolated to model parameter updates only

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/38e31030bd50463aa91d83403aaa8025)