### PR TITLE
Pin agent-sdk dependencies to specific commit

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -35,8 +35,8 @@ dependencies = [
     "gunicorn==21.2.0",
     "requests>=2.31.0",
     "PyNaCl==1.5.0",
-    "openhands-sdk @ git+https://github.com/all-hands-ai/agent-sdk.git@main#subdirectory=openhands/sdk",
-    "openhands-tools @ git+https://github.com/all-hands-ai/agent-sdk.git@main#subdirectory=openhands/tools",
+    "openhands-sdk @ git+https://github.com/all-hands-ai/agent-sdk.git@f8e800a93a3726555a30d1c42a692f4c556187c5#subdirectory=openhands/sdk",
+    "openhands-tools @ git+https://github.com/all-hands-ai/agent-sdk.git@f8e800a93a3726555a30d1c42a692f4c556187c5#subdirectory=openhands/tools",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

This PR pins the agent-sdk dependencies to a specific commit hash instead of tracking the `main` branch, ensuring reproducible builds and preventing unexpected changes from new commits.

## Changes

- **openhands-sdk**: Pinned to commit `f8e800a93a3726555a30d1c42a692f4c556187c5`
- **openhands-tools**: Pinned to commit `f8e800a93a3726555a30d1c42a692f4c556187c5`

## Benefits

- **Reproducible builds**: The project now uses a specific commit instead of tracking the moving main branch
- **Stability**: Prevents unexpected changes from new commits to agent-sdk main branch  
- **Version control**: Clear tracking of which agent-sdk version is being used

## Files Modified

- `backend/pyproject.toml`: Updated dependency URLs to use specific commit hash

## Testing

The changes only affect dependency resolution and don't modify any application logic. The pinned commit represents the current state of the agent-sdk main branch as of the time this PR was created.

## Type of Change

- [x] Dependency update
- [x] Build/CI improvement
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d83926f1bfbe4d309256a16a01701c4b)