### PR TITLE
Remove initial ls command from agent creation

### DIFF
--- a/backend/agents/runtime_handler.py
+++ b/backend/agents/runtime_handler.py
@@ -116,7 +116,7 @@ class RuntimeHandler:
         """
         paths = self.get_runtime_paths()
 
-        info = {
+        info: Dict[str, Any] = {
             "type": "remote" if self.is_remote else "local",
             "workspace_path": self.workspace_path,
             "state_path": self.state_path,

--- a/backend/routes/riffs.py
+++ b/backend/routes/riffs.py
@@ -592,9 +592,7 @@ def create_riff(slug):
             # Continue without runtime - local agent will be used as fallback
 
         # Create AgentLoop with user's Anthropic token
-        success, error_message = create_agent_for_user(
-            user_uuid, slug, riff_slug
-        )
+        success, error_message = create_agent_for_user(user_uuid, slug, riff_slug)
         if not success:
             logger.error(f"❌ Failed to create Agent for riff: {error_message}")
             # Return 500 for git/workspace setup failures, 400 for other client errors

--- a/backend/routes/riffs.py
+++ b/backend/routes/riffs.py
@@ -210,7 +210,7 @@ def reconstruct_agent_from_state(user_uuid, app_slug, riff_slug):
         return False, f"Failed to reconstruct Agent: {str(e)}"
 
 
-def create_agent_for_user(user_uuid, app_slug, riff_slug, send_initial_message=False):
+def create_agent_for_user(user_uuid, app_slug, riff_slug):
     """
     Create and store an Agent object for a specific user, app, and riff.
     This function creates an AgentLoop with Agent and Conversation from openhands-sdk.
@@ -219,7 +219,6 @@ def create_agent_for_user(user_uuid, app_slug, riff_slug, send_initial_message=F
         user_uuid: User's UUID
         app_slug: App slug identifier
         riff_slug: Riff slug identifier
-        send_initial_message: Whether to send initial ls command (only for brand new riffs)
 
     Returns:
         tuple: (success: bool, error_message: str or None)
@@ -342,22 +341,7 @@ def create_agent_for_user(user_uuid, app_slug, riff_slug, send_initial_message=F
                     f"✅ AgentLoop verification successful for {user_uuid[:8]}:{app_slug}:{riff_slug}"
                 )
 
-                if send_initial_message:
-                    try:
-                        project_path = f"{workspace_path}/project"
-                        initial_message = f"run `ls {project_path}` and briefly describe what you see. Do nothing else until the user asks."
-                        logger.debug(
-                            f"📨 Sending initial message to new riff agent for {user_uuid[:8]}:{app_slug}:{riff_slug}: {initial_message}"
-                        )
-                        agent_loop.send_message(initial_message)
-                        logger.debug(
-                            f"✅ Initial message sent successfully to new riff agent"
-                        )
-                    except Exception as e:
-                        logger.error(
-                            f"❌ Failed to send initial message to new riff agent: {e}"
-                        )
-                        # Don't fail the creation if initial message fails
+                # Initial message logic removed - agents will wait for user input
 
                 return True, None
             else:
@@ -609,7 +593,7 @@ def create_riff(slug):
 
         # Create AgentLoop with user's Anthropic token
         success, error_message = create_agent_for_user(
-            user_uuid, slug, riff_slug, send_initial_message=True
+            user_uuid, slug, riff_slug
         )
         if not success:
             logger.error(f"❌ Failed to create Agent for riff: {error_message}")


### PR DESCRIPTION
## Summary

This PR removes the automatic sending of an initial `ls` command when creating new riffs/agents. Previously, when a new riff was created, the system would automatically send a message telling the agent to run `ls {project_path}` and describe what it sees.

## Changes Made

- **Removed initial message logic**: Eliminated the code that automatically sends `ls` commands to new agents
- **Simplified function signature**: Removed the `send_initial_message` parameter from `create_agent_for_user()`
- **Updated documentation**: Cleaned up function docstrings to reflect the changes
- **Updated call sites**: Removed the `send_initial_message=True` parameter from function calls

## Behavior Change

**Before**: When creating a new riff, the agent would automatically receive and execute:
```
run `ls {project_path}` and briefly describe what you see. Do nothing else until the user asks.
```

**After**: Agents wait for explicit user input before taking any actions.

## Files Modified

- `backend/routes/riffs.py`: Removed initial message sending logic from `create_agent_for_user()` function

## Testing

- Code compiles without syntax errors
- No existing tests were found that depend on this behavior
- The change is backward compatible as it only removes automatic behavior

## Rationale

This change gives users more control over their agent interactions by ensuring agents only act when explicitly instructed, rather than performing automatic actions upon creation.

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/19f516812ef84cd9a5b3ff1a2876cd71)